### PR TITLE
Adds Endpoints & Calls for the Spiel Backends

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,7 @@ import SpielEditor from './Editor/SpielEditor';
 import SpielNavbar from './Navbar/SpielNavbar';
 import Home from './HomePage/Home';
 import Tutorial from './Tutorial/Tutorial';
-import Run from './Run/Run';
+import {Run,SpielServerRequest} from './Run/Run';
 
 
 const App: React.FC = () => {
@@ -17,9 +17,6 @@ const App: React.FC = () => {
     let [code, setCode] = React.useState('');
     let [modalShow, setModalShow] = React.useState(false);
 
-    // Change to Backend API
-    const SPIEL_API = "https://jsonplaceholder.typicode.com/todos/1";
-
     function setTheme(theme: string) {
         setEditorTheme(theme);
     }
@@ -28,29 +25,69 @@ const App: React.FC = () => {
         return createBrowserHistory().location.pathname === "/free" || createBrowserHistory().location.pathname === "/tutorial";
     }
 
-    function parse_response(res: JSON) {
-        // Board
-        // Value
-        // Game Result
-        // Parse Error
-        // Type Error
-    }
+    // just a placeholder to run a file on the backend
+    // save a file with a given name of TEMP
+    // run that file
+    function runExample() {
 
-    function run() {
-        setModalShow(true);
-        fetch(
-            SPIEL_API, {
-                method: "GET"
-        }).then(res => res.json()).then((result) => {
-            console.log(result);
-            parse_response(result);
-        });
+      // /read
+      // read a file, auto-adds .bgl extension
+      // returns JSON with 'content' and 'fileName' set
+      // returns...{"fileName":"examples/TicTacToe","content":"..."}
+      /*
+      SpielServerRequest.read('examples/TicTacToe').then(res => res.json()).then(result => {
+        setCode(JSON.stringify(result));
+        //setCode(result.content);
+      });
+      /**/
+
+      // /save
+      // save a file with data
+      // auto-adds the '.bgl' extension, so leave it off
+      // to prevent accidentally overwriting a .hs file or something other than a .bgl file
+      // returns...{"responses":[{"tag":"SpielOK","contents":"TEST.bgl written successfully"}]}
+      /*
+      SpielServerRequest.save('TEST',"2 + 2 * 3").then(res => res.json()).then(result => {
+        setCode(JSON.stringify(result));
+      });
+      /**/
+
+      // /test
+      // example of calling test endpoint, just to make sure it's working
+      // returns...{"responses":[{"tag":"SpielOK","contents":"Spiel is Running!"}]}
+      /*
+      SpielServerRequest.test().then(res => res.json()).then(result => {
+        setCode(JSON.stringify(result));
+      });
+      /**/
+
+      // /runCmds
+      // example of running commands on a file
+      /**/
+      var cmds = [
+        "2 + 2",
+        "3 * 3",
+        "20 / 4",
+        "gameLoop(empty)",
+        "whileTest(1)"
+      ];
+      SpielServerRequest.runCmds('examples/TicTacToe.bgl',cmds).then(res => res.json()).then((result) => {
+        //setModalShow(true);
+        var val = "";
+        for(var x = 0; x < result.responses.length; x++) {
+          val+=cmds[x]+"\n";
+          val+=JSON.stringify(result.responses[x])+"\n";
+        }
+        setCode(val);
+        //setCode(JSON.stringify(result));
+      });
+      /**/
     }
 
     return (
         <>
             <Router>
-                <SpielNavbar modal={run} setTheme={ setTheme } />
+                <SpielNavbar modal={runExample} setTheme={ setTheme } />
                 <Route exact path="/" component={ Home } />
                 <Route exact path="/free" render={(props) => <SpielEditor {...props} editorTheme={ editorTheme } code={ code } setCode={ setCode }/>} />
                 <Route exact path="/tutorial" render={(props) => <Tutorial {...props} editorTheme={ editorTheme } />} />

--- a/src/Run/Run.tsx
+++ b/src/Run/Run.tsx
@@ -2,19 +2,97 @@ import * as React from 'react';
 import Modal from 'react-bootstrap/Modal';
 import Button from 'react-bootstrap/Button';
 
-const Run = (props) => { 
-    
 
+// Class for representing requests
+// that can be made to the Spiel Language Server
+class SpielServerRequest {
+
+  // Change to Backend API
+  static SPIEL_API = "http://localhost:8080";
+
+
+  // creates a new file with the given content
+  // automatically adds '.bgl' to whatever the name is
+  // so 'TEST' will be 'TEST.bgl' serverside
+  // (to protect overwriting existing non-bgl files)
+  static save(fileName,content) {
+    return fetch(SpielServerRequest.SPIEL_API+'/save', {
+      method: 'POST',
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        fileName: fileName,
+        content: content,
+      }),
+    });
+  }
+
+  static read(fileName) {
+    return fetch(SpielServerRequest.SPIEL_API+'/read', {
+      method: 'POST',
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        path: fileName
+      }),
+    });
+  }
+
+
+  // requests the test endpoint,
+  // just to make sure things are working
+  static test() {
+    return fetch(
+        SpielServerRequest.SPIEL_API+"/test", {
+          method: "GET"
+        });
+  }
+
+
+  // "examples/TicTacToe.bgl"
+  // ["2 + 2","3 * 3","20 / 4"]
+  // Runs a file with the given commands
+  static runCmds(fileToUse,commands) {
+    return fetch(SpielServerRequest.SPIEL_API+'/runCmds', {
+      method: 'POST',
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        file: fileToUse,
+        inputs: commands,
+      }),
+    })
+  }
+
+
+  static parse_response(res: JSON) {
+    // TODO needs to be implmeneted
+      // Board
+      // Value
+      // Game Result
+      // Parse Error
+      // Type Error
+  }
+
+}
+
+const Run = (props) => {
     return (
 	<Modal {...props} size="lg" aria-labelledby="contained-modal-title-vcenter" centered>
             <Modal.Body>
-                  
+
             </Modal.Body>
             <Modal.Footer>
                 <Button onClick={props.onHide}>Close</Button>
             </Modal.Footer>
 	</Modal>
-    );
+  )
 }
 
-export default Run;
+export {Run,SpielServerRequest};


### PR DESCRIPTION
Adds SpielServerRequest into Run.tsx. Kind of dumped in there for the moment, but it can be moved as needed. It's a simple class with 4 static functions:
```js
// .bgl added server-side (so you don't save over .hs files)
SpielServerRequest.save("FileToSave","contents...");

// .bgl added server-side (so you don't read .hs files)
SpielServerRequest.read("FileToRead");

// just to test
SpielServerRequest.test();

// file to run, and array of commands to run in order, as you would type in the Repl
SpielServerRequest.runCmds("FileToRun.bgl",["cmd1","cmd2","cmd3",...]);
```
I went ahead and added these all into the App.tsx into a ```runExample``` function, which has examples of each of these calls. I was still playing around with things, so feel free to move stuff around and plug things in where they need to go to.

This is some output from clicking the 'Run' button that populates into the editor, just a proof of concept.

<img width="958" alt="Screen Shot 2020-03-06 at 21 30 05" src="https://user-images.githubusercontent.com/5070304/76137529-fe379000-5ff2-11ea-8050-f63a38a17cc3.png">


I still need to implement the response types (i.e typechecker/parser errror, value, etc.) server-side, but I may not be able to do that until Sunday.

The associated backend from spiel can be fired up (assuming you're on master):
```
$stack install
$stack ghci

>startServer
...server will boot up, logs requests so you can see what's going on...
```
This should be just about everything we need to start building the frontend pieces around. Ideally we should incorporate the cloning, installation and startup of the backend server as part of booting up the frontend (since it shouldn't run without it). That could be integrated in as an npm script, and we can have it 'look' like a 1 click install 👍 .