### PR TITLE
Adds Auto Install & Start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+Spiel-Lang/
+*.bgl

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ Front-end for Spiel language.
 
 This project is bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
-Uses:
+Libraries used:
 * [react-bootstrap](https://react-bootstrap.github.io/)
 * [CodeMirror](https://codemirror.net/)
 * [react-router](https://github.com/ReactTraining/react-router)
 
 ## Installation
 
-First, run `npm install`. To run, use `npm start`. To deploy, use `npm build`.
+Requires ability to run [Spiel-Lang](https://github.com/The-Code-In-Sheep-s-Clothing/Spiel-Lang.git). To install, run `npm run setup`. Then, to start the front-end and back-end servers, run `npm run startProduction`. 
 
 ## Learn More
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "@types/react": "^16.9.17",
     "@types/react-dom": "^16.9.4",
     "bootstrap": "^4.4.1",
-    "forever": "^2.0.0",
     "history": "^4.10.1",
     "latest-version": "^5.1.0",
     "prismjs": "^1.19.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@types/react": "^16.9.17",
     "@types/react-dom": "^16.9.4",
     "bootstrap": "^4.4.1",
+    "forever": "^2.0.0",
     "history": "^4.10.1",
     "latest-version": "^5.1.0",
     "prismjs": "^1.19.0",
@@ -25,7 +26,10 @@
     "typescript": "^3.7.5"
   },
   "scripts": {
+    "setup": "git clone https://github.com/The-Code-In-Sheep-s-Clothing/Spiel-Lang.git && cd Spiel-Lang && stack build && stack install",
     "start": "react-scripts start",
+    "startProduction" : "(react-scripts start &>/dev/null &) && spielserver",
+    "stopProduction"  : "react-scripts stop",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"


### PR DESCRIPTION
This PR adds in auto install and start commands, installing **Spiel-Lang**, building it, and installing it so that a server can be booted up automatically. This is effectively a 2 command sequence:
```bash
# can only do this once, clones current spiel version, and runs commands against it
# note this should be altered to clone a given tag/release instead, so we don't break as master updates
npm run setup

# starts up react in the background, and fires up the Spiel-Server in the foreground
npm run startProduction
```
That's it. Hitting Ctrl-C will kill the Spiel-Server, and will also implicitly kill the react instance as well. Tada!

@anchoryte @alexgrejuc I think this is pretty much our '1 click install' then. Minus cloning this git repo. Having a small script/program that clones this repo and runs these commands would be the end goal.