### PR TITLE
Proxy for Requests to Backend

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "scripts": {
     "setup": "npm install && git clone https://github.com/The-Code-In-Sheep-s-Clothing/Spiel-Lang.git && cd Spiel-Lang && stack build && stack install",
-    "start": "react-scripts start",
+    "start": "PORT=5168 react-scripts start",
     "startProduction": "(react-scripts start &>/dev/null &) && spielserver",
     "stopProduction": "react-scripts stop",
     "build": "react-scripts build",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "bootstrap": "^4.4.1",
     "forever": "^2.0.0",
     "history": "^4.10.1",
+    "http-proxy": "^1.18.1",
+    "http-proxy-middleware": "^1.0.4",
     "latest-version": "^5.1.0",
     "prismjs": "^1.19.0",
     "react": "^16.12.0",

--- a/src/Run/Run.tsx
+++ b/src/Run/Run.tsx
@@ -7,7 +7,7 @@ import Terminal from 'terminal-in-react';
 class SpielServerRequest {
 
     // Change to Backend API
-    static SPIEL_API = "http://localhost:8080";
+    static SPIEL_API = "/api_1";
 
 
     static runCode(prelude_code, code, command, buf) {

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -1,0 +1,31 @@
+//
+// setupProxy.js
+//
+// This enables proxy-like behavior from React to forward requests
+// server-side to our local spielserver instance running on the same machine.
+// By keeping the requests local, we can avoid hitting anything that we don't want to
+//
+
+const { createProxyMiddleware } = require('http-proxy-middleware');
+module.exports = function(app) {
+
+  // test endpoint, verifies spielserver is running
+  app.use(
+    '/api_1/test',
+    createProxyMiddleware({
+      target: 'http://localhost:8080/test',
+      changeOrigin: true,
+      ignorePath: true
+    })
+  );
+
+  // attempts to run this code under the local instance
+  app.use(
+    '/api_1/runCode',
+    createProxyMiddleware({
+      target: 'http://localhost:8080/runCode',
+      changeOrigin: true,
+      ignorePath: true
+    })
+  );
+};

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -13,7 +13,7 @@ module.exports = function(app) {
   app.use(
     '/api_1/test',
     createProxyMiddleware({
-      target: 'http://localhost:8080/test',
+      target: 'http://localhost:5174/test',
       changeOrigin: true,
       ignorePath: true
     })
@@ -23,7 +23,7 @@ module.exports = function(app) {
   app.use(
     '/api_1/runCode',
     createProxyMiddleware({
-      target: 'http://localhost:8080/runCode',
+      target: 'http://localhost:5174/runCode',
       changeOrigin: true,
       ignorePath: true
     })


### PR DESCRIPTION
This is done to fix issues noted with deploying on an EC2 instance. CORS issues were significant, which is apparently due to how Amazon handles incoming AJAX requests to EC2 instances. Basically, it's not possible unless you write up a bunch of other handling (and more instances to setup exposing an API).

A simpler solution was to use the builtin proxy functionality that react ships with. This allows us to create a forward facing endpoint of /api_1/ under the frontend. Any requests to /api_1/runCode or /api_1/test will be redirected server-side to the local spiel-lang instance. This means the requests (from the user's viewpoint) are now all unified under the same origin, and no more CORS issues!

Even with the proxy, the existing flow of a local development setup is the same, it just routes the requests a bit differently. Nothing else needs to be changed for this to work.