### PR TITLE
Adds prelude sharing, updates existing endpoints

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import queryString from 'query-string';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import { BrowserRouter as Router, Route, Link } from "react-router-dom";
 
@@ -19,16 +20,69 @@ const App: React.FC = () => {
     let THEME_KEY = "THEME_KEY";
     let CODE_KEY = "CODE_KEY";
     let PRELUDE_KEY = "PRELUDE_KEY";
+    let LOAD_KEY = "LOAD_KEY";
 
-    // State functions 
+    // State functions
     let [editorTheme, setEditorTheme] = React.useState(localStorage.getItem(THEME_KEY) || "default");
     let [code, setCode] = React.useState(localStorage.getItem(CODE_KEY) || "");
     let [codeP, setCodeP] = React.useState(localStorage.getItem(PRELUDE_KEY) || "");
+    let [shareLink, setShareLink] = React.useState(false);
     let [P, setP] = React.useState(false);
+
+    // checks to load a gamefile & prelude
+    function checkToLoad() {
+      // pull out params
+      const url = window.location.search;
+      let params = queryString.parse(url);
+
+      if(params.p) {
+        // prelude & gamefile given
+        // load up prelude & gamefile code
+        SpielServerRequest.load(params.p).then(function(resp) {
+          return resp.json();
+
+        }).then(function(result) {
+          // load in prelude & gamefile
+          if(result.tag == "SpielLoadResult") {
+            // good
+            setCodeP(result.contents[0]);
+
+            // TODO can uncomment to implement game file changing as well
+            //setCode(result.contents[1]);
+            //localStorage.setItem(CODE_KEY, result.contents[1]);
+
+            localStorage.setItem(PRELUDE_KEY, result.contents[0]);
+
+            // redirect to '/' to avoid changes later on
+            window.location.href = '/';
+
+          } else {
+            console.dir(result);
+            console.error("Error: "+result.contents);
+            alert("Couldn't load in prelude and gamefile!");
+          }
+
+        }).catch(function(err) {
+          // unable to load
+          console.dir(err);
+          alert("Unable to load specific prelude and gamefile! Using what you last had.");
+
+        })
+      }
+    }
 
     function setTheme(theme: string) {
         setEditorTheme(theme);
         localStorage.setItem(THEME_KEY, theme);
+    }
+
+    // shares the prelude and gamefile of this user
+    // returns a string to share
+    function sharePrelude() {
+      // request to share prelude & gamefile, will return a unique filename on success, otherwise failure
+      return SpielServerRequest.share(codeP, code).then(function(resp) {
+        return resp.json();
+      });
     }
 
     function updateCode(c: string) {
@@ -39,12 +93,17 @@ const App: React.FC = () => {
         setCodeP(c);
     }
 
+    function getShareLink() {
+      return shareLink;
+    }
+
     // Updates on change of code or filename
     useEffect(() => {
         updateCode(code);
         updateCodeP(codeP);
         localStorage.setItem(CODE_KEY, code);
         localStorage.setItem(PRELUDE_KEY, codeP);
+        checkToLoad();
     }, [code, codeP, P]);
 
     // Set prelude code or regular code to be displayed
@@ -56,10 +115,10 @@ const App: React.FC = () => {
     return (
         <>
             <Router>
-                <SpielNavbar setTheme={setTheme} />
+                <SpielNavbar setTheme={setTheme} sharePrelude={sharePrelude} setShareLink={setShareLink} getShareLink={getShareLink}/>
                 <Row noGutters={true}>
                     <Col className="move-down tall" sm={8}>
-			<Route className="CodeMirror" exact path="/" render={(props) => 
+			<Route className="CodeMirror" exact path="/" render={(props) =>
                             <>
                                 <Tabs defaultActiveKey="Code" transition={false} id="uncontrolled-tab-example" onSelect={(k) => go(k)}>
                                     <Tab eventKey="Code" title="Code"></Tab>

--- a/src/Navbar/SpielNavbar.tsx
+++ b/src/Navbar/SpielNavbar.tsx
@@ -18,7 +18,7 @@ const SpielNavbar = (props) => {
     function getThemes() {
         let navitems: Array<JSX.Element> = [];
         for (let i = 0; i < themes.length; i++) {
-            navitems.push(<NavDropdown.Item onClick={() => props.setTheme(themes[i]) }>{ themes[i] }</NavDropdown.Item>);
+            navitems.push(<NavDropdown.Item key={i} onClick={() => props.setTheme(themes[i]) }>{ themes[i] }</NavDropdown.Item>);
 
         }
         return navitems;
@@ -29,6 +29,26 @@ const SpielNavbar = (props) => {
         // This disables reload
         e.preventDefault();
         props.save();
+    }
+
+    function getShareOption() {
+      if(props.getShareLink() != "") {
+        // share link is set
+        return <Form.Control type="email" value={window.location.href + "?p=" + props.getShareLink()}/>
+
+      } else {
+        // share link has not been generated yet
+        return <Button variant="outline-light" title="Generates share link for Prelude" type="button" onClick={() => props.sharePrelude().then(function(result) {
+          if(result[0].tag == "SpielSuccess") {
+            props.setShareLink(result[0].contents);
+          } else {
+            alert("Unable to share!");
+          }
+        }).catch(function(err) {
+          alert("Failed to share!");
+        })}>Share</Button>
+      }
+
     }
 
     // Uses React-Router to change page
@@ -43,6 +63,9 @@ const SpielNavbar = (props) => {
                         {getThemes()}
                     </NavDropdown>
                 </Nav>
+                <Form inline>
+                  {getShareOption()}
+                </Form>
             </Navbar.Collapse>
         </Navbar>
     );

--- a/src/Run/Run.tsx
+++ b/src/Run/Run.tsx
@@ -10,6 +10,59 @@ class SpielServerRequest {
     static SPIEL_API = "/api_1";
 
 
+    // Access the test endpoint, checks if the server is online
+    static test() {
+      return fetch(SpielServerRequest.SPIEL_API+'/test', {method: 'GET'});
+    }
+
+
+    // Saves contents to a given filename
+    static share(preludeContent, gamefileContent) {
+      return fetch(SpielServerRequest.SPIEL_API+'/share', {
+          method: 'POST',
+          headers: {
+              'Accept': 'application/json',
+              'Content-Type': 'application/json'
+          },
+          body: JSON.stringify({
+              preludeContent: preludeContent,
+              gameContent: gamefileContent
+          })
+      });
+    }
+
+
+    // Used to load up both a prelude & gamefile simultaneously
+    static load(id) {
+      return fetch(SpielServerRequest.SPIEL_API+'/load', {
+          method: 'POST',
+          headers: {
+              'Accept': 'application/json',
+              'Content-Type': 'application/json'
+          },
+          body: JSON.stringify({
+              fileName: id
+          })
+      });
+    }
+
+
+    // Reads a file by the given name
+    static read(filename) {
+      return fetch(SpielServerRequest.SPIEL_API+'/read', {
+          method: 'POST',
+          headers: {
+              'Accept': 'application/json',
+              'Content-Type': 'application/json'
+          },
+          body: JSON.stringify({
+              path: filename
+          })
+      });
+    }
+
+
+    // Runs a command on a given prelude and gamefile contents, with input as well
     static runCode(prelude_code, code, command, buf) {
         return fetch(SpielServerRequest.SPIEL_API+'/runCode', {
             method: 'POST',
@@ -20,26 +73,6 @@ class SpielServerRequest {
             body: JSON.stringify({
                 prelude: prelude_code,
                 file: code,
-                input: command,
-                buffer: buf
-            }),
-        })
-    }
-
-    // "examples/TicTacToe.bgl"
-    // ["2 + 2","3 * 3","20 / 4"]
-    // Runs a file with the given commands
-    static runCmds(preludeFile, fileToUse, command, buf) {
-        return fetch(SpielServerRequest.SPIEL_API+'/runCmds', {
-            method: 'POST',
-            //mode: 'no-cors',
-            headers: {
-                'Accept': 'application/json',
-                'Content-Type': 'application/json'
-            },
-            body: JSON.stringify({
-                prelude: preludeFile,
-                file: fileToUse,
                 input: command,
                 buffer: buf
             }),

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -19,6 +19,26 @@ module.exports = function(app) {
     })
   );
 
+  // saving
+  app.use(
+    '/api_1/share',
+    createProxyMiddleware({
+      target: 'http://localhost:5174/share',
+      changeOrigin: true,
+      ignorePath: true
+    })
+  );
+
+  // loading
+  app.use(
+    '/api_1/load',
+    createProxyMiddleware({
+      target: 'http://localhost:5174/load',
+      changeOrigin: true,
+      ignorePath: true
+    })
+  );
+
   // attempts to run this code under the local instance
   app.use(
     '/api_1/runCode',


### PR DESCRIPTION
Closes #34 by allowing individuals to share their preludes by a url. An additional PR on the backend [here](https://github.com/The-Code-In-Sheep-s-Clothing/Spiel-Lang/pull/94) will be required to be merged first so that the endpoints this uses will be correctly setup.

This also removes references to outdated endpoints, and adds the 'share' and 'load' endpoints for saving and loading prelude/gamefile data. Although it should be noted that this can work for both of them, it's currently only setup for sharing preludes, with the gamefile part commented out in case we want it later on.