### PR TITLE
Hides (Most) Typescript Errors

### DIFF
--- a/src/Run/Run.tsx
+++ b/src/Run/Run.tsx
@@ -201,7 +201,7 @@ const Run = (props) => {
           if((error instanceof SyntaxError || (error.name && error.name == "SyntaxError")) && respStatus == 504) {
             // gateway timeout
             console.dir(error);
-            print("[ 🤖 BoGL Says: I am offline, please check back later! ]");
+            print("[ 🤖 BoGL Says: Unable to finish running your program, or not currently online. Double check your code, or check back later! ]");
 
           } else if((error instanceof SyntaxError || (error.name && error.name == "SyntaxError"))) {
             // bad parse error


### PR DESCRIPTION
Closes #7 by hiding most typescript errors from the user. This looks at commonly encountered frontend issues, such as javascript being disabled, or the backend server being unreachable. In these cases, a more friendly response has been added, with the addition of `[ 🤖 BoGL Says: ... ]`.

Running something like `1/0` will crash the backend and not properly return a response. This comes back as a nebulous error, because the 504 gateway timeout looks identical to when the server is also unreachable. This is something else that needs to be handled server side as a legitimate runtime error (likely a try/catch).

This still allows some very extreme circumstances to show up in case something odd happens. In that case we will want the error, so we can add a cleaner case for it, but I haven't personally seen any errors get through this new setup.