### PR TITLE
Sharing Fixes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,16 +1,14 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import queryString from 'query-string';
 import 'bootstrap/dist/css/bootstrap.min.css';
-import { BrowserRouter as Router, Route, Link } from "react-router-dom";
+import { BrowserRouter as Router, Route } from "react-router-dom";
 
 import SpielEditor from './Editor/SpielEditor';
 import SpielNavbar from './Navbar/SpielNavbar';
-import Tutorial from './Tutorial/Tutorial';
 import { Run, SpielServerRequest } from './Run/Run';
 
 import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
-import Container from 'react-bootstrap/Container';
 import Tabs from 'react-bootstrap/Tabs';
 import Tab from 'react-bootstrap/Tab';
 
@@ -20,14 +18,30 @@ const App: React.FC = () => {
     let THEME_KEY = "THEME_KEY";
     let CODE_KEY = "CODE_KEY";
     let PRELUDE_KEY = "PRELUDE_KEY";
-    let LOAD_KEY = "LOAD_KEY";
+    let SHARE_KEY = "SHARE_KEY";
 
     // State functions
     let [editorTheme, setEditorTheme] = React.useState(localStorage.getItem(THEME_KEY) || "default");
     let [code, setCode] = React.useState(localStorage.getItem(CODE_KEY) || "");
     let [codeP, setCodeP] = React.useState(localStorage.getItem(PRELUDE_KEY) || "");
+    let [shareLoaded, setShareLoaded] = React.useState(localStorage.getItem(SHARE_KEY) || "");
     let [shareLink, setShareLink] = React.useState(false);
     let [P, setP] = React.useState(false);
+
+
+    // update the prelude used in the Editor
+    function updatePreludeContent(content: string) {
+      setCodeP(content);
+      localStorage.setItem(PRELUDE_KEY, content);
+    }
+
+
+    // update the code used in the Editor
+    function updateCodeContent(content: string) {
+      setCode(content);
+      localStorage.setItem(CODE_KEY, content);
+    }
+
 
     // checks to load a gamefile & prelude
     function checkToLoad() {
@@ -35,26 +49,41 @@ const App: React.FC = () => {
       const url = window.location.search;
       let params = queryString.parse(url);
 
-      if(params.p) {
-        // prelude & gamefile given
+      console.info("shareLoaded: " + shareLoaded);
+      console.info("params.p: " + params.p);
+
+      if(params.p && params.s && shareLoaded !== params.p) {
+        // code & share option given
         // load up prelude & gamefile code
         SpielServerRequest.load(params.p).then(function(resp) {
           return resp.json();
-
         }).then(function(result) {
           // load in prelude & gamefile
-          if(result.tag == "SpielLoadResult") {
-            // good
-            setCodeP(result.contents[0]);
+          if(result.tag === "SpielLoadResult") {
+            // good, now load based on share option
+            if(params.s === 0) {
+              // prelude only
+              updatePreludeContent(result.contents[0]);
 
-            // TODO can uncomment to implement game file changing as well
-            //setCode(result.contents[1]);
-            //localStorage.setItem(CODE_KEY, result.contents[1]);
+            } else if(params.s === 1) {
+              // code only
+              updateCodeContent(result.contents[1]);
 
-            localStorage.setItem(PRELUDE_KEY, result.contents[0]);
+            } else if(params.s === 2) {
+              // both
+              updatePreludeContent(result.contents[0]);
+              updateCodeContent(result.contents[1]);
 
-            // redirect to '/' to avoid changes later on
-            window.location.href = '/';
+            } else {
+              // bad share option
+              console.warn("The share option code provided was unrecognized: "+params.s);
+              alert("Invalid share option given: "+ params.s);
+
+            }
+
+            // update that this share has been loaded, so we don't need to reload it again
+            setShareLoaded(params.p);
+            localStorage.setItem(SHARE_KEY, params.p);
 
           } else {
             //console.dir(result);
@@ -68,6 +97,10 @@ const App: React.FC = () => {
           alert("Unable to load specific prelude and gamefile! Using what you last had.");
 
         })
+      } else {
+        // already shared, can skip
+        console.info("Already loaded share, skipping");
+
       }
     }
 
@@ -104,11 +137,13 @@ const App: React.FC = () => {
         localStorage.setItem(CODE_KEY, code);
         localStorage.setItem(PRELUDE_KEY, codeP);
         checkToLoad();
+        // (complains about CODE_KEY, PRELUDE_KEY, and checkToLoad, which are all present already)
+        // eslint-disable-next-line
     }, [code, codeP, P]);
 
     // Set prelude code or regular code to be displayed
     function go(k: string) {
-        setP(k == "Prelude");
+        setP(k === "Prelude");
     }
 
     // Parent to Editor, Tutorial, and Run (terminal)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,9 +49,6 @@ const App: React.FC = () => {
       const url = window.location.search;
       let params = queryString.parse(url);
 
-      console.info("shareLoaded: " + shareLoaded);
-      console.info("params.p: " + params.p);
-
       if(params.p && params.s && shareLoaded !== params.p) {
         // code & share option given
         // load up prelude & gamefile code
@@ -100,10 +97,6 @@ const App: React.FC = () => {
           alert("Unable to load specific prelude and gamefile! Using what you last had.");
 
         })
-      } else {
-        // already shared, can skip
-        console.info("Already loaded share, skipping");
-
       }
     }
 
@@ -135,10 +128,8 @@ const App: React.FC = () => {
 
     // Updates on change of code or filename
     useEffect(() => {
-        updateCode(code);
-        updateCodeP(codeP);
-        localStorage.setItem(CODE_KEY, code);
-        localStorage.setItem(PRELUDE_KEY, codeP);
+        updateCodeContent(code);
+        updatePreludeContent(codeP);
         checkToLoad();
         // (complains about CODE_KEY, PRELUDE_KEY, and checkToLoad, which are all present already)
         // eslint-disable-next-line

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,18 +58,21 @@ const App: React.FC = () => {
         SpielServerRequest.load(params.p).then(function(resp) {
           return resp.json();
         }).then(function(result) {
+
+          let shareOption = parseInt(params.s);
+
           // load in prelude & gamefile
           if(result.tag === "SpielLoadResult") {
             // good, now load based on share option
-            if(params.s === 0) {
+            if(shareOption === 0) {
               // prelude only
               updatePreludeContent(result.contents[0]);
 
-            } else if(params.s === 1) {
+            } else if(shareOption === 1) {
               // code only
               updateCodeContent(result.contents[1]);
 
-            } else if(params.s === 2) {
+            } else if(shareOption === 2) {
               // both
               updatePreludeContent(result.contents[0]);
               updateCodeContent(result.contents[1]);

--- a/src/Editor/BoGLHighlight.tsx
+++ b/src/Editor/BoGLHighlight.tsx
@@ -17,7 +17,7 @@ function BoGLHighlight() {
   let hexitRE = /[0-9A-Fa-f]/;
   let octitRE = /[0-7]/;
   let idRE = /[a-z_A-Z0-9'\xa1-\uffff]/;
-  let symbolRE = /[-!#$%&*+.\/<=>?@\\^|~:]/;
+  let symbolRE = /[-!#$%&*+./<=>?@\\^|~:]/;
   let specialRE = /[(),;[\]`{}]/;
   let whiteCharRE = /[ \t\v\f]/; // newlines are handled in tokenizer
 
@@ -28,8 +28,8 @@ function BoGLHighlight() {
 
     let ch = source.next();
     if (specialRE.test(ch)) {
-      if (ch == '{' && source.eat('-')) {
-        var t = "comment";
+      if (ch === '{' && source.eat('-')) {
+        let t = "comment";
         if (source.eat('#')) {
           t = "meta";
         }
@@ -38,7 +38,7 @@ function BoGLHighlight() {
       return null;
     }
 
-    if (ch == '\'') {
+    if (ch === '\'') {
       if (source.eat('\\')) {
         source.next();  // should handle other escapes here
       }
@@ -51,7 +51,7 @@ function BoGLHighlight() {
       return "string error";
     }
 
-    if (ch == '"') {
+    if (ch === '"') {
       return switchState(source, setState, stringLiteral);
     }
 
@@ -69,7 +69,7 @@ function BoGLHighlight() {
     }
 
     if (digitRE.test(ch)) {
-      if (ch == '0') {
+      if (ch === '0') {
         if (source.eat(/[xX]/)) {
           source.eatWhile(hexitRE); // should require at least 1
           return "integer";
@@ -80,7 +80,7 @@ function BoGLHighlight() {
         }
       }
       source.eatWhile(digitRE);
-      var t = "number";
+      let t = "number";
       if (source.match(/^\.\d+/)) {
         t = "number";
       }
@@ -92,19 +92,19 @@ function BoGLHighlight() {
       return t;
     }
 
-    if (ch == "." && source.eat("."))
+    if (ch === "." && source.eat("."))
       return "keyword";
 
     if (symbolRE.test(ch)) {
-      if (ch == '-' && source.eat(/-/)) {
+      if (ch === '-' && source.eat(/-/)) {
         source.eatWhile(/-/);
         if (!source.eat(symbolRE)) {
           source.skipToEnd();
           return "comment";
         }
       }
-      var t = "variable";
-      if (ch == ':') {
+      let t = "variable";
+      if (ch === ':') {
         t = "variable-2";
       }
       source.eatWhile(symbolRE);
@@ -115,19 +115,19 @@ function BoGLHighlight() {
   }
 
   function ncomment(type, nest) {
-    if (nest == 0) {
+    if (nest === 0) {
       return normal;
     }
     return function(source, setState) {
       var currNest = nest;
       while (!source.eol()) {
         var ch = source.next();
-        if (ch == '{' && source.eat('-')) {
+        if (ch === '{' && source.eat('-')) {
           ++currNest;
         }
-        else if (ch == '-' && source.eat('}')) {
+        else if (ch === '-' && source.eat('}')) {
           --currNest;
-          if (currNest == 0) {
+          if (currNest === 0) {
             setState(normal);
             return type;
           }
@@ -141,11 +141,11 @@ function BoGLHighlight() {
   function stringLiteral(source, setState) {
     while (!source.eol()) {
       var ch = source.next();
-      if (ch == '"') {
+      if (ch === '"') {
         setState(normal);
         return "string";
       }
-      if (ch == '\\') {
+      if (ch === '\\') {
         if (source.eol() || source.eat(whiteCharRE)) {
           setState(stringGap);
           return "string";
@@ -186,7 +186,7 @@ function BoGLHighlight() {
 
     // keyword sequences
     setType("keyword",
-      ["\.\.", ":", "\\", "<-", "->", "!", "="]);
+      ["..", ":", "\\", "<-", "->", "!", "="]);
 
     // highlight operators (same as types)
     setType("builtin",

--- a/src/Editor/SpielEditor.tsx
+++ b/src/Editor/SpielEditor.tsx
@@ -1,10 +1,7 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import {Controlled as CodeMirror} from 'react-codemirror2';
 import 'codemirror/lib/codemirror.css';
-
-import Container from 'react-bootstrap/Container';
 import BoGLHighlight from './BoGLHighlight';
-
 import 'codemirror/theme/midnight.css';
 import 'codemirror/theme/gruvbox-dark.css';
 import 'codemirror/theme/solarized.css';
@@ -13,8 +10,6 @@ import 'codemirror/theme/nord.css';
 import './SpielEditor.css';
 
 const SpielEditor = (props) => {
-
-    let [editor, setEditor] = React.useState();
 
     function updateCode(value: string) {
         props.updateCode(value);

--- a/src/Editor/SpielEditor.tsx
+++ b/src/Editor/SpielEditor.tsx
@@ -29,6 +29,11 @@ const SpielEditor = (props) => {
                 options={{
                     lineWrapping: true,
                     tabSize: 3,
+
+                    extraKeys: {Enter: function(cm) {
+                      cm.replaceSelection("\n");
+                    }},
+
                     lineNumbers: true,
                     mode: 'bogl',
                     theme: props.editorTheme,

--- a/src/Navbar/Share.tsx
+++ b/src/Navbar/Share.tsx
@@ -39,8 +39,8 @@ class Share extends React.Component<ShareProps> {
       <Form.Control id="preludeShare" className="hidden" ref={this.codeShareRef} type="url" value={baseURL + "?p=" + this.props.shareLink + "&s=1"}/>
       <Form.Control id="preludeShare" className="hidden" ref={this.bothShareRef} type="url" value={baseURL + "?p=" + this.props.shareLink + "&s=2"}/>
 
-      <Form.Control id="shareLinkButton" type="button" onClick={() => this.copyToClipboard(this.preludeShareRef)} value="P" title="Share Prelude Only"/>
-      <Form.Control id="shareLinkButton" type="button" onClick={() => this.copyToClipboard(this.codeShareRef)} value="C" title="Share Code Only"/>
+      <Form.Control id="shareLinkButton" className="right-padd" type="button" onClick={() => this.copyToClipboard(this.preludeShareRef)} value="P" title="Share Prelude Only"/>
+      <Form.Control id="shareLinkButton" className="right-padd" type="button" onClick={() => this.copyToClipboard(this.codeShareRef)} value="C" title="Share Code Only"/>
       <Form.Control id="shareLinkButton" type="button" onClick={() => this.copyToClipboard(this.bothShareRef)} value="P & C" title="Share Both"/>
     </>);
   }

--- a/src/Navbar/Share.tsx
+++ b/src/Navbar/Share.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import Form from 'react-bootstrap/Form';
+
+interface ShareProps {
+  shareLink: string
+}
+
+class Share extends React.Component<ShareProps> {
+
+
+  // share references
+  // prelude share ref
+  preludeShareRef : any = React.createRef();
+  // code share ref
+  codeShareRef : any = React.createRef();
+  // code & prelude share ref
+  bothShareRef : any = React.createRef();
+
+
+  //
+  // Allows Copy to Clipboard Behavior
+  // Pulled & Based on the W3C's example @ https://www.w3schools.com/howto/howto_js_copy_clipboard.asp
+  //
+  copyToClipboard(ref) {
+    ref.current.select();
+    // Copy the text inside the text field
+    document.execCommand("copy");
+    alert("Copied to Clipboard!");
+  }
+
+
+  render() {
+
+    // trim off the ?... end part of the URL
+    const baseURL = window.location.href.replace(/\?p=.*$/,'');
+
+    return (<>
+      <Form.Control id="preludeShare" ref={this.preludeShareRef} type="url" value={baseURL + "?p=" + this.props.shareLink + "&s=0"}/>
+      <Form.Control id="preludeShare" className="hidden" ref={this.codeShareRef} type="url" value={baseURL + "?p=" + this.props.shareLink + "&s=1"}/>
+      <Form.Control id="preludeShare" className="hidden" ref={this.bothShareRef} type="url" value={baseURL + "?p=" + this.props.shareLink + "&s=2"}/>
+
+      <Form.Control id="shareLinkButton" type="button" onClick={() => this.copyToClipboard(this.preludeShareRef)} value="P" title="Share Prelude Only"/>
+      <Form.Control id="shareLinkButton" type="button" onClick={() => this.copyToClipboard(this.codeShareRef)} value="C" title="Share Code Only"/>
+      <Form.Control id="shareLinkButton" type="button" onClick={() => this.copyToClipboard(this.bothShareRef)} value="P & C" title="Share Both"/>
+    </>);
+  }
+
+}
+
+export default Share;

--- a/src/Navbar/SpielNavbar.css
+++ b/src/Navbar/SpielNavbar.css
@@ -2,3 +2,12 @@
     position: sticky;
     top: 0;
 }
+
+/* Item still on the page, but essentially invisible */
+.hidden {
+  width: 0 !important;
+  height: 0 !important;
+  margin: 0 !important;
+  padding: 0 !important;
+  opacity: 0 !important;
+}

--- a/src/Navbar/SpielNavbar.css
+++ b/src/Navbar/SpielNavbar.css
@@ -3,6 +3,10 @@
     top: 0;
 }
 
+.right-padd {
+  margin-right: 4px;
+}
+
 /* Item still on the page, but essentially invisible */
 .hidden {
   width: 0 !important;

--- a/src/Navbar/SpielNavbar.tsx
+++ b/src/Navbar/SpielNavbar.tsx
@@ -2,11 +2,10 @@ import * as React from 'react';
 import Navbar from 'react-bootstrap/Navbar';
 import Nav from 'react-bootstrap/Nav';
 import NavDropdown from 'react-bootstrap/NavDropdown';
-import { BrowserRouter as NavLink, Link } from "react-router-dom";
+import { Link } from "react-router-dom";
 import Form from 'react-bootstrap/Form';
-import FormControl from 'react-bootstrap/FormControl';
 import Button from 'react-bootstrap/Button';
-import SpielEditor from '../Editor/SpielEditor';
+import Share from './Share';
 
 import './SpielNavbar.css';
 
@@ -20,13 +19,12 @@ const SpielNavbar = (props) => {
         let navitems: Array<JSX.Element> = [];
         for (let i = 0; i < themes.length; i++) {
             navitems.push(<NavDropdown.Item key={i} onClick={() => props.setTheme(themes[i]) }>{ themes[i] }</NavDropdown.Item>);
-
         }
         return navitems;
     }
 
     // examples available
-    const boglExamples: Array<Array<string>> = [
+    let boglExamples: Array<Array<string>> = [
       ["Simplest Program","-- Simple Program example\ngame Simple\ntype Board = Array(1,1) of Int\ntype Input = Int"],
       ["Function", "--example of a function\ngame FunctionExample\ntype Board = Array(1,1) of Int\ntype Input = Int\n\nf : Int\nf = 1"],
       ["Function with Parameter", "--example of a function that takes a parameter\ngame FunctionParamExample\ntype Board = Array(1,1) of Int\ntype Input = Int\n\n--adds 1 to whatever number we give this function\nf : Int -> Int\nf(x) = x + 1"],
@@ -45,22 +43,16 @@ const SpielNavbar = (props) => {
         return navitems;
     }
 
-    // When users press enter to submit save request, automatically reloads page
-    function handleSubmit(e: any) {
-        // This disables reload
-        e.preventDefault();
-        props.save();
-    }
 
     function getShareOption() {
-      if(props.getShareLink() != "") {
-        // share link is set
-        return <Form.Control type="email" value={window.location.href + "?p=" + props.getShareLink()}/>
+      if(props.getShareLink() !== "") {
+        // share link is ready to display, show it!
+        return <Share shareLink={props.getShareLink()}/>;
 
       } else {
-        // share link has not been generated yet
-        return <Button variant="outline-light" title="Generates share link for Prelude" type="button" onClick={() => props.sharePrelude().then(function(result) {
-          if(result[0].tag == "SpielSuccess") {
+        // share link has NOT been generated yet
+        return <Button variant="outline-light" title="Generates share link for Prelude" type="button" onClick={(e) => props.sharePrelude().then(function(result) {
+          if(result[0].tag === "SpielSuccess") {
             props.setShareLink(result[0].contents);
           } else {
             alert("Unable to share!");

--- a/src/Navbar/SpielNavbar.tsx
+++ b/src/Navbar/SpielNavbar.tsx
@@ -11,6 +11,8 @@ import './SpielNavbar.css';
 
 const SpielNavbar = (props) => {
 
+    let [didShare, setDidShare] = React.useState(false);
+
     // Themes available
     const themes: Array<string> = ["default", "midnight", "gruvbox-dark", "solarized", "nord"];
 
@@ -45,7 +47,7 @@ const SpielNavbar = (props) => {
 
 
     function getShareOption() {
-      if(props.getShareLink() !== "") {
+      if(didShare) {
         // share link is ready to display, show it!
         return <Share shareLink={props.getShareLink()}/>;
 
@@ -53,12 +55,17 @@ const SpielNavbar = (props) => {
         // share link has NOT been generated yet
         return <Button variant="outline-light" title="Generates share link for Prelude" type="button" onClick={(e) => props.sharePrelude().then(function(result) {
           if(result[0].tag === "SpielSuccess") {
+            // update that we shared and modify link
+            setDidShare(true);
             props.setShareLink(result[0].contents);
+
           } else {
             alert("Unable to share!");
+
           }
         }).catch(function(err) {
           alert("Failed to share!");
+          
         })}>Share</Button>
       }
 

--- a/src/Run/Run.tsx
+++ b/src/Run/Run.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 // import Form from 'react-bootstrap/Form';
 import Terminal from 'terminal-in-react';
 
@@ -211,7 +211,7 @@ const Run = (props) => {
     // only print one board, but that is a much less common use case that the first one.
     function extendBoardsString(board, value, boards) {
         var boardStr = get_board(board["value"]);
-        if (boardStr != value) boards = boards + boardStr + value + "\n";
+        if (boardStr !== value) boards = boards + boardStr + value + "\n";
     }
 
     // Pushes item to command's input
@@ -236,22 +236,22 @@ const Run = (props) => {
           print(parse_response(result));
 
         }).catch((error) => {
-          if((error instanceof SyntaxError || (error.name && error.name == "SyntaxError")) && respStatus == 504) {
+          if((error instanceof SyntaxError || (error.name && error.name === "SyntaxError")) && respStatus === 504) {
             // gateway timeout
             //console.dir(error);
             print("[ 🤖 BoGL Says: Unable to finish running your program, or not currently online. Double check your code, or check back later! ]");
 
-          } else if((error instanceof SyntaxError || (error.name && error.name == "SyntaxError"))) {
+          } else if((error instanceof SyntaxError || (error.name && error.name === "SyntaxError"))) {
             // bad parse error
             //console.dir(error);
             print("[ 🤖 BoGL Says: Your program was unable to be understood. Please double check it and try again! ]");
 
-          } else if((error instanceof TypeError || (error.name && error.name == "TypeError")) && respStatus == 0) {
+          } else if((error instanceof TypeError || (error.name && error.name === "TypeError")) && respStatus === 0) {
             // likely JS disabled
             //console.dir(error);
             print("[ 🤖 BoGL Says: Unable to execute your program. Make sure that Javascript is enabled and try again! ]");
 
-          } else if((error instanceof TypeError || (error.name && error.name == "TypeError"))) {
+          } else if((error instanceof TypeError || (error.name && error.name === "TypeError"))) {
             // something else?
             //console.dir(error);
             print("[ 🤖 BoGL Says: Unable to execute your program, please double check your code and try again. ]");


### PR DESCRIPTION
Closes #43, closes #44, closes #42, and closes #48 . Fixes code sharing so that there is no need to double refresh the screen, as items are updated on the initial load. This also adds in 3 sharing options, one for the prelude, one for code, and one for both of them at once. The same url is modified with an additional GET parameter of mode 0,1,2 to indicate one of these respective sharing modes.