### PR TITLE
Sharing Adjustments

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spiel-front",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "homepage": "./",
   "private": true,
   "dependencies": {

--- a/src/Navbar/Share.tsx
+++ b/src/Navbar/Share.tsx
@@ -34,15 +34,23 @@ class Share extends React.Component<ShareProps> {
     // trim off the ?... end part of the URL
     const baseURL = window.location.href.replace(/\?p=.*$/,'');
 
+    // copy on loading in
     return (<>
-      <Form.Control id="preludeShare" ref={this.preludeShareRef} type="url" value={baseURL + "?p=" + this.props.shareLink + "&s=0"}/>
+      <Form.Control id="shareLinkButton" type="button" className="right-padd" onClick={() => this.copyToClipboard(this.bothShareRef)} value="Copy" title="Copy the share link"/>
+      <Form.Control id="preludeShare" className="right-padd" ref={this.bothShareRef} type="url" readOnly value={baseURL + "?p=" + this.props.shareLink + "&s=2"}/>
+    </>);
+
+    /*
+    return (<>
+      <Form.Control id="preludeShare" ref={this.bothShareRef} type="url" value={baseURL + "?p=" + this.props.shareLink + "&s=2"}/>
       <Form.Control id="preludeShare" className="hidden" ref={this.codeShareRef} type="url" value={baseURL + "?p=" + this.props.shareLink + "&s=1"}/>
-      <Form.Control id="preludeShare" className="hidden" ref={this.bothShareRef} type="url" value={baseURL + "?p=" + this.props.shareLink + "&s=2"}/>
+      <Form.Control id="preludeShare" className="hidden" ref={this.preludeShareRef} type="url" value={baseURL + "?p=" + this.props.shareLink + "&s=0"}/>
 
       <Form.Control id="shareLinkButton" className="right-padd" type="button" onClick={() => this.copyToClipboard(this.preludeShareRef)} value="P" title="Share Prelude Only"/>
       <Form.Control id="shareLinkButton" className="right-padd" type="button" onClick={() => this.copyToClipboard(this.codeShareRef)} value="C" title="Share Code Only"/>
       <Form.Control id="shareLinkButton" type="button" onClick={() => this.copyToClipboard(this.bothShareRef)} value="P & C" title="Share Both"/>
     </>);
+    */
   }
 
 }

--- a/src/Run/Run.tsx
+++ b/src/Run/Run.tsx
@@ -150,8 +150,6 @@ const Run = (props) => {
         let res: string = "";
         let switch_mode: string = "";
         let boards: string = "";
-        //console.log(responses);
-        //console.log(latest);
 
         // Check if inputState switched
         switch (latest["tag"]) {
@@ -267,7 +265,6 @@ const Run = (props) => {
         let regex = /^:t\s+/;
         if(cmd.match(regex)) {
           // pull off the prefaced type instruction, but note that we would like to report a type once done
-          console.info("Replacing!!!");
           cmd = cmd.replace(regex,'');
           setReportType(true);
           reportType = true;
@@ -282,7 +279,6 @@ const Run = (props) => {
         SpielServerRequest.runCode(codeP, code, (cmd === "" ? command : cmd), commandInput)
         .then(function(res) {
           // decode this response
-          //console.dir(res);
           respStatus = res.status;
           return res.json();
 


### PR DESCRIPTION
Closes #53 
- adds a reset button
- simplifies sharing to a single share option (no more P, C, and P & C, as sharing only part of a program was usually a bug)
- only shows the sharing link and copy button (for sharing both code & prelude) until changes are made. 
    - This clarifies that sharing is only for the current state of the program, any changes require a re-share.