### PR TITLE
Visual Changes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -166,8 +166,8 @@ const App: React.FC = () => {
                     <Col className="move-down tall" sm={8}>
 			<Route className="CodeMirror" exact path="/" render={(props) =>
                             <>
-                                <Tabs defaultActiveKey="Code" transition={false} id="uncontrolled-tab-example" onSelect={(k) => go(k)}>
-                                    <Tab eventKey="Code" title="Code"></Tab>
+                                <Tabs defaultActiveKey="Program" transition={false} id="uncontrolled-tab-example" onSelect={(k) => go(k)}>
+                                    <Tab eventKey="Program" title="Program"></Tab>
                                     <Tab eventKey="Prelude" title="Prelude"></Tab>
                                 </Tabs>
                                 <SpielEditor {...props} code={(P ? codeP : code)} editorTheme={editorTheme} updateCode={(P ? updateCodeP : updateCode)}/>

--- a/src/Navbar/SpielNavbar.css
+++ b/src/Navbar/SpielNavbar.css
@@ -15,3 +15,14 @@
   padding: 0 !important;
   opacity: 0 !important;
 }
+
+.icon {
+  border-radius: 4px;
+  border: solid rgb(223,237,250) 2px;
+  margin-top: -3px;
+  margin-right: 10px;
+}
+
+.align-navlink {
+  margin-bottom: -4px;
+}

--- a/src/Navbar/SpielNavbar.tsx
+++ b/src/Navbar/SpielNavbar.tsx
@@ -120,14 +120,20 @@ const SpielNavbar = (props) => {
         {getBoGLExamples()}
     </NavDropdown>
     */
+
+    /*
+    Old 'Editor' link, redundant, went right before 'Themes' below
+    <Nav.Link as={Link} to="/">Editor</Nav.Link>
+    */
+
     return (
         <Navbar bg="danger" variant="dark" expand="lg" fixed="top">
-            <Navbar.Brand>BoGL: Board Game Language</Navbar.Brand>
+            <Navbar.Brand><img src="favicon.ico" className="icon" width="26" height="26"/> BoGL: Board Game Language</Navbar.Brand>
             <Navbar.Toggle aria-controls="basic-navbar-nav" />
             <Navbar.Collapse id="basic-navbar-nav">
                 <Nav className="mr-auto">
-                    <Nav.Link as={Link} to="/">Editor</Nav.Link>
-                    <NavDropdown title="Themes" id="basic-nav-dropdown">
+
+                    <NavDropdown title="Themes" id="basic-nav-dropdown" className="align-navlink">
                         {getThemes()}
                     </NavDropdown>
 


### PR DESCRIPTION
Closes #56 in part, with the help docs coming in on a separate repo, to form the website. 

Makes some visual changes as requested (and some others added):
- Changes "Code" to "Program" on the editor tabs
- Adds a small BoGL icon to the left of the page name in the navbar
- Removes the 'Editor' tab, as this is redundant, there isn't anything else besides the editor in this tool
- Slightly adjusts the margin positioning of 'Themes' to better align it with the site name position